### PR TITLE
[chore] Update yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1454,8 +1454,8 @@ growly@^1.2.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
 handlebars@^4.0.1, handlebars@^4.0.3:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.6.tgz#2ce4484850537f9c97a8026d5399b935c4ed4ed7"
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.7.tgz#e97325aeb8ea0b9e12b9c4dd73c4c312ad0ede59"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"


### PR DESCRIPTION
This automated pull request updates yarn.lock to all the latest versions. If you do not want to continue getting these pull requests, you can update your settings at https://makelatest.com

This pull request will be automatically merged if the tests pass